### PR TITLE
Fix docker image name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Before you begin, you'll need:
 
 ## Usage
 
-Launch your backend container and note its name, then launch `smashwilson/tls-nginx` with the following parameters:
+Launch your backend container and note its name, then launch `smashwilson/lets-nginx` with the following parameters:
 
  * `--link backend:backend` to link your backend service's container to this one. *(This may be unnecessary depending on Docker's [networking configuration](https://docs.docker.com/engine/userguide/networking/dockernetworks/).)*
  * `-e EMAIL=` your email address, used to register with letsencrypt.


### PR DESCRIPTION
I think `tls-nginx` referred to an older version?
