### PR TITLE
Provide basic templating of nginx configuration files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN ln -sf /dev/stderr /var/log/nginx/error.log
 RUN mkdir -p /etc/letsencrypt/webrootauth
 
 ADD entrypoint.sh /entrypoint.sh
+ADD templates /templates
 
 EXPOSE 80 443
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Launch your backend container and note its name, then launch `smashwilson/lets-n
  * `-e DOMAIN=` the domain name.
  * `-e UPSTREAM=` the name of your backend container and the port on which the service is listening.
  * `-p 80:80` and `-p 443:443` so that the letsencrypt client and nginx can bind to those ports on your public interface.
- * `-e STAGING=1` uses the Let's Encrypt *staging server* instead of the production one. 
-            I highly recommend using this option to double check your infrastructure before you launch a real service. 
-            Let's Encrypt rate-limits the production server to issuing 
-            [five certificates per domain per seven days](https://community.letsencrypt.org/t/public-beta-rate-limits/4772/3), 
+ * `-e STAGING=1` uses the Let's Encrypt *staging server* instead of the production one.
+            I highly recommend using this option to double check your infrastructure before you launch a real service.
+            Let's Encrypt rate-limits the production server to issuing
+            [five certificates per domain per seven days](https://community.letsencrypt.org/t/public-beta-rate-limits/4772/3),
             which (as I discovered the hard way) you can quickly exhaust by debugging unrelated problems!
-            
+
 ## Caching the Certificates and/or DH Parameters
 
 Since `--link`s don't survive the re-creation of the target container, you'll need to coordinate re-creating
@@ -70,4 +70,23 @@ docker run --detach \
   -v letsencrypt-backups:/var/lib/letsencrypt \
   -v dhparam-cache:/cache \
   smashwilson/lets-nginx
+```
+
+## Adjusting Nginx configuration
+
+The entry point of this image processes the files in `/templates` and
+places the result of each file in `/etc/nginx` with the same file name.
+The following variable substitutions are made while processing those files:
+
+* `${DOMAIN}`
+* `${UPSTREAM}`
+
+For example, to adjust `nginx.conf`, create that file in your new image directory
+with the [baseline content](templates/nginx.conf) and desired modifications.
+Within your `Dockerfile` *ADD* this file  and it will get used by the image entry point.
+
+```docker
+FROM smashwilson/lets-nginx
+
+ADD nginx.conf /templates/nginx.conf
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,73 +41,15 @@ chown nginx:nginx /var/cache/nginx
 mkdir -p /var/tmp/nginx
 chown nginx:nginx /var/tmp/nginx
 
-# Template an nginx.conf
-cat <<EOF >/etc/nginx/nginx.conf
-user nginx;
-worker_processes 2;
-
-events {
-  worker_connections 1024;
-}
-
-http {
-  include mime.types;
-  default_type application/octet-stream;
-  
-  proxy_cache_path /var/cache/nginx keys_zone=anonymous:10m;
-  proxy_temp_path /var/tmp/nginx;
-
-  sendfile on;
-  tcp_nopush on;
-  keepalive_timeout 65;
-
-  access_log /var/log/nginx/access.log;
-  error_log /var/log/nginx/error.log;
-
-  server {
-    listen 443 ssl;
-    server_name "${DOMAIN}";
-
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-    ssl_dhparam /etc/ssl/dhparams.pem;
-
-    ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_session_cache shared:SSL:10m;
-    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
-    ssl_session_tickets off;
-    ssl_stapling on;
-    ssl_stapling_verify on;
-
-    root /etc/letsencrypt/webrootauth;
-
-    location / {
-      proxy_pass http://${UPSTREAM};
-      proxy_set_header Host \$host;
-      proxy_set_header X-Forwarded-For \$remote_addr;
-      proxy_cache   anonymous;
-    }
-
-    location /.well-known/acme-challenge {
-      alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
-      location ~ /.well-known/acme-challenge/(.*) {
-        add_header Content-Type application/jose+json;
-      }
-    }
-  }
-
-  # Redirect from port 80 to port 443
-  server {
-    listen 80;
-    server_name "${DOMAIN}";
-    return 301 https://\$server_name\$request_uri;
-  }
-}
-EOF
+# Process templates
+for t in /templates/*
+do
+  dest="/etc/nginx/$(basename $t)"
+  echo "Rendering template of $dest"
+  sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
+      -e "s/\${UPSTREAM}/${UPSTREAM}/" \
+      $t > $dest
+done
 
 # Initial certificate request, but skip if cached
 if [ ! -f /etc/letsencrypt/live/${DOMAIN}/fullchain.pem ]; then

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,0 +1,64 @@
+user nginx;
+worker_processes 2;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include mime.types;
+  default_type application/octet-stream;
+
+  proxy_cache_path /var/cache/nginx keys_zone=anonymous:10m;
+  proxy_temp_path /var/tmp/nginx;
+
+  sendfile on;
+  tcp_nopush on;
+  keepalive_timeout 65;
+
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
+
+  server {
+    listen 443 ssl;
+    server_name "${DOMAIN}";
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    ssl_dhparam /etc/ssl/dhparams.pem;
+
+    ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    root /etc/letsencrypt/webrootauth;
+
+    location / {
+      proxy_pass http://${UPSTREAM};
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_cache   anonymous;
+    }
+
+    location /.well-known/acme-challenge {
+      alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
+      location ~ /.well-known/acme-challenge/(.*) {
+        add_header Content-Type application/jose+json;
+      }
+    }
+  }
+
+  # Redirect from port 80 to port 443
+  server {
+    listen 80;
+    server_name "${DOMAIN}";
+    return 301 https://$server_name$request_uri;
+  }
+}


### PR DESCRIPTION
Since the entry point script is `sh` (and not `bash`), I resorted to simple `sed` substitutions rather than the templating trick I mentioned in #6 .

When converting over to a template file for nginx.conf I had to remove some backslash escapes, so you may want to double check me there.
