### PR TITLE
Include Strict Transport Security on error pages

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -31,7 +31,7 @@ http {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
-    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload" always;
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
     ssl_session_tickets off;


### PR DESCRIPTION
In our "lets-nginx" deployment we added basic auth, and so the SSL Labs client (or any unauthenticated client) was receiving 401s. By default, [nginx ignores "add_header" directives on error pages](http://serverfault.com/a/418717), and so we downgraded to a mere A grade because we weren't sending back the Strict-Transport-Security header on errors.

This change to the nginx configuration ensures an A+ grade even when serving error pages (and also closes an extremely narrow window of downgrade attack around the same). I'm not familiar with the other two headers, so I'm not sure if the same change should be applied to them as well – if so, just let me know and I'll be happy to update the PR.
