### PR TITLE
Added the possibility to configure multiple destinations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.2
+FROM alpine:latest
 MAINTAINER Ash Wilson <smashwilson@gmail.com>
 
-RUN apk add --update nginx \
+#We need to install bash to easily handle arrays
+# in the entrypoint.sh script
+RUN apk add --update nginx bash \
   python python-dev py-pip \
   gcc musl-dev linux-headers \
   augeas-dev openssl-dev libffi-dev ca-certificates dialog \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:latest
 MAINTAINER Ash Wilson <smashwilson@gmail.com>
 
 RUN apk add --update nginx \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Launch your backend container and note its name, then launch `smashwilson/lets-n
 
 ### Using more than one backend service
 
-You can set up multiple proxy destinations, matching the host name. This is usefull if you have more than one container you want to access in https
+You can set up multiple proxy destinations, matching the host name. This is usefull if you have more than one container you want to access with https
 
 To do so, simply set the DOMAIN and UPSTREAM env variables accordingly :
 ```bash
@@ -52,7 +52,6 @@ To do so, simply set the DOMAIN and UPSTREAM env variables accordingly :
 -e UPSTREAM="backend:8080;172.17.0.5:60;container:5000"
 ``` 
 The values are separated by `;`.
-A
 
 ## Caching the Certificates and/or DH Parameters
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ docker run --detach \
 
 ## Adjusting Nginx configuration
 
-The entry point of this image copy the `nginx.conf`file in `/templates` to `/etc/nginx/nginx.conf` and one ore several file in `/etc/nginx/vhosts` with the the appropriate domain name, e.g `/etc/nginx/vhosts/domain1.com.conf`.
+The entry point of this image processes the  `nginx.conf` file in `/templates` and places the result in `/etc/nginx` with the same file name.
+Also, one ore several files are created in `/etc/nginx/vhosts` with the the appropriate domain name, e.g `/etc/nginx/vhosts/domain1.com.conf`.
+
 The following variable substitutions are made while processing those files:
 
 * `${DOMAIN}`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Launch your backend container and note its name, then launch `smashwilson/lets-n
             [five certificates per domain per seven days](https://community.letsencrypt.org/t/public-beta-rate-limits/4772/3),
             which (as I discovered the hard way) you can quickly exhaust by debugging unrelated problems!
 
+### Using more than one backend service
+
+You can set up multiple proxy destinations, matching the host name. This is usefull if you have more than one container you want to access in https
+
+To do so, simply set the DOMAIN and UPSTREAM env variables accordingly :
+```bash
+-e DOMAIN="domain1.com;sub.domain1.com;another.domain.net"
+-e UPSTREAM="backend:8080;172.17.0.5:60;container:5000"
+``` 
+The values are separated by `;`.
+A
+
 ## Caching the Certificates and/or DH Parameters
 
 Since `--link`s don't survive the re-creation of the target container, you'll need to coordinate re-creating
@@ -74,8 +86,7 @@ docker run --detach \
 
 ## Adjusting Nginx configuration
 
-The entry point of this image processes the files in `/templates` and
-places the result of each file in `/etc/nginx` with the same file name.
+The entry point of this image copy the `nginx.conf`file in `/templates` to `/etc/nginx/nginx.conf` and one ore several file in `/etc/nginx/vhosts` with the the appropriate domain name, e.g `/etc/nginx/vhosts/domain1.com.conf`.
 The following variable substitutions are made while processing those files:
 
 * `${DOMAIN}`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,14 +75,16 @@ do
   upstreamId=$((upstreamId+1))
 done
 
-
+letscmd=""
 for d in "${DOMAINSARRAY[@]}"
 do
+  letscmd="$letscmd --domain $d"
+done
 
 # Initial certificate request, but skip if cached
   if [ ! -f /etc/letsencrypt/live/"${d}"/fullchain.pem ]; then
     letsencrypt certonly \
-      --domain "${d}" \
+      ${letscmd} \
       --standalone \
       --email "${EMAIL}" --agree-tos
   fi
@@ -97,15 +99,15 @@ do
   letsencrypt certonly --force-renewal \
     --webroot \
     -w /etc/letsencrypt/webrootauth/ \
-    --domain "${d}" \
+    ${letscmd} \
     --email "${EMAIL}" --agree-tos
 
   # Reload nginx configuration to pick up the reissued certificates
   /usr/sbin/nginx -s reload
 EOF
 
-chmod +x /etc/periodic/monthly/reissue-"${d}"
-done
+chmod +x /etc/periodic/monthly/reissue
+
 # Kick off cron to reissue certificates as required
 # Background the process and log to stderr
 /usr/sbin/crond -f -d 8 &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,7 @@ cp templates/nginx.conf /etc/nginx/nginx.conf
 
 # Process templates
 upstreamId=0
+letscmd=""
 for t in "${DOMAINSARRAY[@]}"
 do
   dest="/etc/nginx/vhosts/$(basename "${t}").conf"
@@ -73,12 +74,9 @@ do
       -e "s/\${UPSTREAM}/${UPSTREAMARRAY[upstreamId]}/" \
       /templates/vhost.sample.conf > "$dest"
   upstreamId=$((upstreamId+1))
-done
 
-letscmd=""
-for d in "${DOMAINSARRAY[@]}"
-do
-  letscmd="$letscmd --domain $d"
+  #prepare the letsencrypt command arguments
+  letscmd="$letscmd --domain $t"
 done
 
 # Initial certificate request, but skip if cached

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,8 +60,13 @@ chown nginx:nginx /var/tmp/nginx
 #create vhost directory
 mkdir -p /etc/nginx/vhosts/
 
-# Copy nginx main conf file.
-cp templates/nginx.conf /etc/nginx/nginx.conf
+# Process the nginx.conf with ra values of $DOMAIN and $UPSTREAM to ensure backward-compatibility
+  dest="/etc/nginx/vhosts/nginx.conf"
+  echo "Rendering template of nginx.conf"
+  sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
+      -e "s/\${UPSTREAM}/${DOMAIN}/" \
+      /templates/nginx.conf > "$dest"
+
 
 # Process templates
 upstreamId=0
@@ -76,7 +81,7 @@ do
   upstreamId=$((upstreamId+1))
 
   #prepare the letsencrypt command arguments
-  letscmd="$letscmd --domain $t"
+  letscmd="$letscmd --domain $t "
 done
 
 # Initial certificate request, but skip if cached

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,8 +55,7 @@ done
 if [ ! -f /etc/letsencrypt/live/${DOMAIN}/fullchain.pem ]; then
   letsencrypt certonly \
     --domain ${DOMAIN} \
-    --authenticator standalone \
-    ${SERVER} \
+    --standalone \
     --email "${EMAIL}" --agree-tos
 fi
 
@@ -67,10 +66,10 @@ cat <<EOF >/etc/periodic/monthly/reissue
 set -euo pipefail
 
 # Certificate reissue
-letsencrypt certonly --renew-by-default \
+letsencrypt certonly --force-renewal \
+  --webroot \
+  -w /etc/letsencrypt/webrootauth/ \
   --domain "${DOMAIN}" \
-  --authenticator webroot \
-  --webroot-path /etc/letsencrypt/webrootauth/ ${SERVER} \
   --email "${EMAIL}" --agree-tos
 
 # Reload nginx configuration to pick up the reissued certificates

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,8 +60,8 @@ chown nginx:nginx /var/tmp/nginx
 #create vhost directory
 mkdir -p /etc/nginx/vhosts/
 
-# Process the nginx.conf with ra values of $DOMAIN and $UPSTREAM to ensure backward-compatibility
-  dest="/etc/nginx/vhosts/nginx.conf"
+# Process the nginx.conf with raw values of $DOMAIN and $UPSTREAM to ensure backward-compatibility
+  dest="/etc/nginx/nginx.conf"
   echo "Rendering template of nginx.conf"
   sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
       -e "s/\${UPSTREAM}/${DOMAIN}/" \

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -19,46 +19,7 @@ http {
   access_log /var/log/nginx/access.log;
   error_log /var/log/nginx/error.log;
 
-  server {
-    listen 443 ssl;
-    server_name "${DOMAIN}";
-
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-    ssl_dhparam /etc/ssl/dhparams.pem;
-
-    ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_session_cache shared:SSL:10m;
-    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload" always;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
-    ssl_session_tickets off;
-    ssl_stapling on;
-    ssl_stapling_verify on;
-
-    root /etc/letsencrypt/webrootauth;
-
-    location / {
-      proxy_pass http://${UPSTREAM};
-      proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
-      proxy_cache   anonymous;
-    }
-
-    location /.well-known/acme-challenge {
-      alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
-      location ~ /.well-known/acme-challenge/(.*) {
-        add_header Content-Type application/jose+json;
-      }
-    }
+  #Include the vhost files.
+  include vhosts/*.conf;
   }
 
-  # Redirect from port 80 to port 443
-  server {
-    listen 80;
-    server_name "${DOMAIN}";
-    return 301 https://$server_name$request_uri;
-  }
-}

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -1,0 +1,42 @@
+server {
+    listen 443 ssl;
+    server_name "${DOMAIN}";
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    ssl_dhparam /etc/ssl/dhparams.pem;
+
+    ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload" always;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    root /etc/letsencrypt/webrootauth;
+
+    location / {
+      proxy_pass http://${UPSTREAM};
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_cache   anonymous;
+    }
+
+    location /.well-known/acme-challenge {
+      alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
+      location ~ /.well-known/acme-challenge/(.*) {
+        add_header Content-Type application/jose+json;
+      }
+    }
+  }
+
+  # Redirect from port 80 to port 443
+  server {
+    listen 80;
+    server_name "${DOMAIN}";
+    return 301 https://$server_name$request_uri;
+  }


### PR DESCRIPTION
Using to the domain name.

The goal of this PR is two resolve the problem that you cannot have multiple container binded to the same port (obviously..)
You can now run the container with `-e DOMAIN="domain1.com;domain2.com"`
The UPSTREAM env value need to specify the different backend services, 1 per domain.

I also updated the FROM directory in the dockerfile, in order to pull the latest version of alpine.
Bash is also installed to help handle the arrays needed in the script.

Few changes have also been made in the letsencrypt command, which was outdated (the --authenticator option is no longer recognized, as well as --renew by default).
I tested this on my machine, it's building and running fine.
I hope this help, please let me know if you have any issues :)
