### PR TITLE
lets encrypt & alpine updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:latest
 MAINTAINER Ash Wilson <smashwilson@gmail.com>
 
 RUN apk add --update nginx \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,8 +55,7 @@ done
 if [ ! -f /etc/letsencrypt/live/${DOMAIN}/fullchain.pem ]; then
   letsencrypt certonly \
     --domain ${DOMAIN} \
-    --authenticator standalone \
-    ${SERVER} \
+    --standalone \
     --email "${EMAIL}" --agree-tos
 fi
 
@@ -67,10 +66,10 @@ cat <<EOF >/etc/periodic/monthly/reissue
 set -euo pipefail
 
 # Certificate reissue
-letsencrypt certonly --renew-by-default \
+letsencrypt certonly --force-renewal \
+  --webroot \
+  -w /etc/letsencrypt/webrootauth/ \
   --domain "${DOMAIN}" \
-  --authenticator webroot \
-  --webroot-path /etc/letsencrypt/webrootauth/ ${SERVER} \
   --email "${EMAIL}" --agree-tos
 
 # Reload nginx configuration to pick up the reissued certificates


### PR DESCRIPTION
As told [here](https://github.com/smashwilson/lets-nginx/pull/9#issuecomment-199384660) this is a separated PR to update the let's encrypt command, because the `--authenticator` and `renew-by-default` options are not longer recognized by letsencrypt
I also set `alpine:latest` to be sure we use the latest version :smile: 
