### PR TITLE
Allow embedded documents from SAMEORIGIN

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -5,7 +5,6 @@ events {
   worker_connections 1024;
 }
 
-
 # config to don't allow the browser to render the page inside an frame or iframe
 # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
 # if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -5,12 +5,6 @@ events {
   worker_connections 1024;
 }
 
-# config to don't allow the browser to render the page inside an frame or iframe
-# and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
-# if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri
-# https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
-add_header X-Frame-Options SAMEORIGIN;
-
 http {
   include mime.types;
   default_type application/octet-stream;
@@ -27,5 +21,11 @@ http {
 
   #Include the vhost files.
   include vhosts/*.conf;
+
+  # config to don't allow the browser to render the page inside an frame or iframe
+  # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+  # if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri
+  # https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+  add_header X-Frame-Options SAMEORIGIN;
 }
 

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -5,6 +5,13 @@ events {
   worker_connections 1024;
 }
 
+
+# config to don't allow the browser to render the page inside an frame or iframe
+# and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+# if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri
+# https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+add_header X-Frame-Options SAMEORIGIN;
+
 http {
   include mime.types;
   default_type application/octet-stream;
@@ -21,5 +28,5 @@ http {
 
   #Include the vhost files.
   include vhosts/*.conf;
-  }
+}
 

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -21,11 +21,5 @@ http {
 
   #Include the vhost files.
   include vhosts/*.conf;
-
-  # config to don't allow the browser to render the page inside an frame or iframe
-  # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
-  # if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri
-  # https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
-  add_header X-Frame-Options SAMEORIGIN;
 }
 

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -11,7 +11,7 @@ server {
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
     add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload" always;
-    add_header X-Frame-Options DENY;
+    add_header X-Frame-Options SAMEORIGIN;
     add_header X-Content-Type-Options nosniff;
     ssl_session_tickets off;
     ssl_stapling on;


### PR DESCRIPTION
Your policy on embedded documents was too strict for my project.

Because `svg` were treated as document on my webpage, I was not allowed to embed them in an `object` tag.

I got confused as to where to put the directive, but finally, here it is :)
