### PR TITLE
wrong directory for customs files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,9 +76,9 @@ do
   dest="/etc/nginx/vhosts/$(basename "${t}").conf"
   src="/templates/vhost.sample.conf"
 
-  if [ -r /configs/"${t}".conf ]; then
+  if [ -r /templates/"${t}".conf ]; then
     echo "Manual configuration found for $t"
-    src="/configs/${t}.conf"
+    src="/templates/${t}.conf"
   fi
 
   echo "Rendering template of $t in $dest"

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -13,6 +13,7 @@ http {
   proxy_temp_path /var/tmp/nginx;
 
   sendfile on;
+  client_max_body_size 20M;
   tcp_nopush on;
   keepalive_timeout 65;
 


### PR DESCRIPTION
The custom configurations vhosts files are searched in `/configs`, and that directory is not created in the dockerfile.

This fixes it and now search for custom configs file in /templates. Files must be created in the templates directory like this `sub.domain.com.conf` and they will be applied with the according domain name passed in the `DOMAIN` argument.
