### PR TITLE
Add HTTP/2 support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,9 +76,9 @@ do
   dest="/etc/nginx/vhosts/$(basename "${t}").conf"
   src="/templates/vhost.sample.conf"
 
-  if [ -r /templates/"${t}".conf ]; then
+  if [ -r /configs/"${t}".conf ]; then
     echo "Manual configuration found for $t"
-    src="/templates/${t}.conf"
+    src="/configs/${t}.conf"
   fi
 
   echo "Rendering template of $t in $dest"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,9 +76,9 @@ do
   dest="/etc/nginx/vhosts/$(basename "${t}").conf"
   src="/templates/vhost.sample.conf"
 
-  if [ -r /configs/"${t}".conf ]; then
+  if [ -r /templates/"${t}".conf ]; then
     echo "Manual configuration found for $t"
-    src="/configs/${t}.conf"
+    src="/templates/${t}.conf"
   fi
 
   echo "Rendering template of $t in $dest"

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -13,6 +13,7 @@ http {
   proxy_temp_path /var/tmp/nginx;
 
   sendfile on;
+  client_max_body_size 20M;
   tcp_nopush on;
   keepalive_timeout 65;
 

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -40,7 +40,7 @@ server {
 
   # Redirect from port 80 to port 443
   server {
-    listen 80;
+    listen 80 http2;
     server_name ${DOMAIN};
     return 301 https://$server_name$request_uri;
   }

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -1,5 +1,5 @@
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
     server_name ${DOMAIN};
 
     ssl_certificate /etc/letsencrypt/live/${PATH}/fullchain.pem;


### PR DESCRIPTION
NGINX now supports HTTP/2 in it's "stable" branch (1.10), let's speed up our webserver ! 

https://www.nginx.com/blog/nginx-1-10-1-11-released/

Alpine ships the latests version : http://pkgs.alpinelinux.org/packages?name=nginx&branch=&repo=&arch=&maintainer=
