### PR TITLE
switch to official NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-FROM alpine:latest
+FROM nginx:alpine
 MAINTAINER Ash Wilson <smashwilson@gmail.com>
 
 #We need to install bash to easily handle arrays
 # in the entrypoint.sh script
-RUN apk add --update nginx bash \
+RUN apk add --update bash \
   python python-dev py-pip \
   gcc musl-dev linux-headers \
   augeas-dev openssl-dev libffi-dev ca-certificates dialog \
   && rm -rf /var/cache/apk/*
-
-RUN chown -R nginx:nginx /var/lib/nginx/
 
 RUN pip install -U letsencrypt
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,5 +153,4 @@ chmod +x /etc/periodic/monthly/reissue
 
 echo Ready
 # Launch nginx in the foreground
-#/bin/bash
 /usr/sbin/nginx -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,4 +153,5 @@ chmod +x /etc/periodic/monthly/reissue
 
 echo Ready
 # Launch nginx in the foreground
+#/bin/bash
 /usr/sbin/nginx -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,9 +76,9 @@ do
   dest="/etc/nginx/vhosts/$(basename "${t}").conf"
   src="/templates/vhost.sample.conf"
 
-  if [ -r /templates/"${t}".conf ]; then
+  if [ -r /configs/"${t}".conf ]; then
     echo "Manual configuration found for $t"
-    src="/templates/${t}.conf"
+    src="/configs/${t}.conf"
   fi
 
   echo "Rendering template of $t in $dest"


### PR DESCRIPTION
For some reason, alpine doesn't use the latest NGINX image available in the repo..... 
I tried to log in the container, and couldn't update nginx to 1.10, even with `apk update && apk upgrade && apk add --update nginx` .....

The NGINX offical dockerfile use alpine 3.3, so not a lot of change for us :) 
https://hub.docker.com/_/nginx/
https://github.com/nginxinc/docker-nginx/blob/11fc019b2be3ad51ba5d097b1857a099c4056213/mainline/alpine/Dockerfile

i also removed the `chown` : it was raising an error. I tried to upload a large a file and everything went smooth, so we're all good :)
