### PR TITLE
Remove http2 module from vhosts

### DIFF
--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -40,7 +40,7 @@ server {
 
   # Redirect from port 80 to port 443
   server {
-    listen 80 http2;
+    listen 80;
     server_name ${DOMAIN};
     return 301 https://$server_name$request_uri;
   }


### PR DESCRIPTION
This causes nginx to return binary data instead of redirecting the user
as intended. The issue is described in this [SO question](http://serverfault.com/questions/792825/nginx-proxy-returns-binary-data)

This commit closes smashwilson/lets-nginx#26
