### PR TITLE
Add X-Forwarded-Proto to default vhost configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Ash Wilson <smashwilson@gmail.com>
 RUN apk add --update bash \
   python python-dev py-pip \
   gcc musl-dev linux-headers \
-  augeas-dev openssl-dev libffi-dev ca-certificates dialog \
+  augeas-dev openssl openssl-dev libffi-dev ca-certificates dialog \
   && rm -rf /var/cache/apk/*
 
 RUN pip install -U letsencrypt

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -23,6 +23,7 @@ server {
       proxy_pass http://${UPSTREAM};
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_cache   anonymous;
       proxy_buffering off;
       proxy_http_version 1.1;


### PR DESCRIPTION
Setting up jenkins behind `lets-nginx` I noticed it would give a warning about the proxy configuration. It mentions several possible causes, but it's just that the X-Forwarded-Proto header is missing from the proxied requests. The background configuration [is described here](https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy).

During testing of this modification the entrypoint script failed to find `openssl`, but adding the package via `apk` resolved that.
