### PR TITLE
Upgrade to certbot and use Alpine's distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN ln -sf /dev/stderr /var/log/nginx/error.log
 # used for webroot reauth
 RUN mkdir -p /etc/letsencrypt/webrootauth
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /opt/entrypoint.sh
 ADD templates /templates
 
 EXPOSE 80 443
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,9 @@ MAINTAINER Ash Wilson <smashwilson@gmail.com>
 #We need to install bash to easily handle arrays
 # in the entrypoint.sh script
 RUN apk add --update bash \
-  python python-dev py-pip \
-  gcc musl-dev linux-headers \
-  augeas-dev openssl openssl-dev libffi-dev ca-certificates dialog \
+  certbot \
+  openssl openssl-dev ca-certificates \
   && rm -rf /var/cache/apk/*
-
-RUN pip install -U letsencrypt
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,7 +115,7 @@ fi
     echo "The SAN list has changed, removing the old certificate and ask for a new one."
     rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
    
-   echo "letsencrypt certonly "${letscmd}" \
+   echo "certbot certonly "${letscmd}" \
     --standalone --text \
     "${SERVER}" \
     --email "${EMAIL}" --agree-tos \
@@ -139,7 +139,7 @@ echo "Creating a cron job to keep the certificate updated"
 set -euo pipefail
 
 # Certificate reissue
-letsencrypt certonly --force-renewal \
+certbot certonly --force-renewal \
 --webroot --text \
 -w /etc/letsencrypt/webrootauth/ \
 ${letscmd} \


### PR DESCRIPTION
I had encountered some errors that seem to have been fixed via #32 ; however, I would like to propose this upgrade to what is now called `certbot` (see the last paragraph [here](https://certbot.eff.org/docs/intro.html#introduction)) and also use the Alpine distribution copy of it.

FYI I have retained the `--text` addition made by #32 
