### PR TITLE
remove http:// in front of ${UPSTREAM}

### DIFF
--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -20,7 +20,7 @@ server {
     root /etc/letsencrypt/webrootauth;
 
     location / {
-      proxy_pass http://${UPSTREAM};
+      proxy_pass ${UPSTREAM};
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Should be usefull the possbility to choise the protocoll:

-e UPSTREAM="backend:8080;172.17.0.5:60;container:5000"
-e UPSTREAM="http://backend:8080;http://172.17.0.5:60;https://container:5000"

I used a custom template to do that.