### PR TITLE
Switch from TLS-SNI to HTTP-01 domain validation method

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,14 +14,14 @@ MISSING=""
 if [ "${MISSING}" != "" ]; then
   echo "Missing required environment variables:" >&2
   echo " ${MISSING}" >&2
-  exit 1 
+  exit 1
   fi
 
 #Processing DOMAIN into an array
 DOMAINSARRAY=($(echo "${DOMAIN}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}'))
 echo "Provided domains"
 printf "%s\n" "${DOMAINSARRAY[@]}"
-  
+
 #Processing UPSTREAM into an array
 UPSTREAMARRAY=($(echo "${UPSTREAM}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}'))
 echo "Services to reverse-proxy"
@@ -103,11 +103,11 @@ if [ ! -f /etc/letsencrypt/san_list ]; then
  "${DOMAIN}"
 EOF
   fresh=true
-else 
+else
   old_san=$(cat /etc/letsencrypt/san_list)
   if [ "${DOMAIN}" != "${old_san}" ]; then
     fresh=true
-  else 
+  else
     fresh=false
   fi
 fi
@@ -116,13 +116,13 @@ fi
 if [ $fresh = true ]; then
   echo "The SAN list has changed, removing the old certificate and ask for a new one."
   rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
- 
+
  echo "certbot certonly "${letscmd}" \
-  --standalone --text \
+  --standalone --preferred-challenges http --text \
   "${SERVER}" \
   --email "${EMAIL}" --agree-tos \
   --expand " > /etc/nginx/lets
-  
+
   echo "Running initial certificate request... "
   /bin/bash /etc/nginx/lets
 fi


### PR DESCRIPTION
According to the [latest post](https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188) by Let's Encrypt community, a vulnerability has been found in the ACME TLS-SNI domain validation process. Therefore, TLS-SNI validation has been permanently disabled.

The [official recommendation](https://community.letsencrypt.org/t/tls-sni-challenges-disabled-for-most-new-issuance/50316) by Let's Encrypt stuff is to migrate the existing validation process to either HTTP-01 or DNS-01.

This pull request switches TLS-SNI validation to HTTP-01. I've also removed all trailing spaces in the entrypoint.sh.

This method has been tested on my own domain.