### PR TITLE
Use ACMEv2 staging server URL

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 # Default other parameters
 STAGING=${STAGING:-0}
 if [ "$STAGING" = "1" ] ; then
-    SERVER="--server https://acme-staging.api.letsencrypt.org/directory"
+    SERVER="--server https://acme-staging-v02.api.letsencrypt.org/directory"
 else
     SERVER=""
 fi


### PR DESCRIPTION
Since ACMEv1 will not work in the short term: [link](https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430)