### PR TITLE
Switch to debian-based nginx image, install ACMEv2 certbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM nginx:alpine
+FROM nginx
 MAINTAINER Ash Wilson <smashwilson@gmail.com>
 
 #We need to install bash to easily handle arrays
 # in the entrypoint.sh script
-RUN apk add --update bash \
+RUN apt-get update && apt-get install -y \
   certbot \
-  openssl openssl-dev ca-certificates \
-  && rm -rf /var/cache/apk/*
+  && rm -rf /var/lib/apt/lists/*
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -134,14 +134,14 @@ echo "${DOMAIN}" > /etc/letsencrypt/san_list
 mkdir -p /etc/letsencrypt/webrootauth/
 
 # Template a cronjob to renew certificate with the webroot authenticator
-echo "Creating a cron job to keep the certificate updated"
-  cat <<EOF >/etc/periodic/weekly/renew
+CRONFILE=/etc/cron.daily/renew
+cat <<EOF >${CRONFILE}
 #!/bin/sh
 # First renew certificate, then reload nginx config
 certbot renew --webroot --webroot-path /etc/letsencrypt/webrootauth/ --post-hook "/usr/sbin/nginx -s reload"
 EOF
 
-chmod +x /etc/periodic/weekly/renew
+chmod +x ${CRONFILE}
 
 # Kick off cron to reissue certificates as required
 # Background the process and log to stderr


### PR DESCRIPTION
Fixes #47 

I haven't yet confirmed that the cronjob is properly kicking off but I'll know tomorrow.

Also note that it uses `cron.daily` to schedule the renew instead of `weekly`. However, that's something I had changed in my fork already, because in a swarm you can get several failures when renewing (due to challenges getting load-balanced away from the correct node). So I wanted the higher frequency of retries.