### PR TITLE
Cron fix & gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,48 @@
+image: docker:latest
+services:
+- docker:dind
+
+
+variables:
+  IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+
+
+stages:
+  - build
+  - release
+
+
+before_script:
+  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+
+
+build-sha:
+  stage: build
+  script:
+    - docker build --pull -t $IMAGE .
+    - docker push $IMAGE
+
+
+.release_script: &release_script
+  script:
+    - docker pull $IMAGE
+    - docker tag $IMAGE $RELEASE_IMAGE
+    - docker push $RELEASE_IMAGE
+
+
+release-latest:
+  stage: release
+  only:
+    - master
+  variables:
+    RELEASE_IMAGE: $CI_REGISTRY_IMAGE:latest
+  <<: *release_script
+
+
+release-tag:
+  stage: release
+  only:
+    - tags
+  variables:
+    RELEASE_IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+  <<: *release_script

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL Ash Wilson <smashwilson@gmail.com>
 # in the entrypoint.sh script
 RUN apt-get update && apt-get install -y \
   certbot \
+  cron \
   && rm -rf /var/lib/apt/lists/*
 
 # forward request and error logs to docker log collector

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx
-LABEL Ash Wilson <smashwilson@gmail.com>
+LABEL maintainer=Ash Wilson <smashwilson@gmail.com>
 
 #We need to install bash to easily handle arrays
 # in the entrypoint.sh script

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx
-MAINTAINER Ash Wilson <smashwilson@gmail.com>
+LABEL Ash Wilson <smashwilson@gmail.com>
 
 #We need to install bash to easily handle arrays
 # in the entrypoint.sh script

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ if [ "${MISSING}" != "" ]; then
   echo "Missing required environment variables:" >&2
   echo " ${MISSING}" >&2
   exit 1
-  fi
+fi
 
 #Processing DOMAIN into an array
 DOMAINSARRAY=($(echo "${DOMAIN}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}'))
@@ -65,11 +65,11 @@ chown nginx:nginx /var/tmp/nginx
 mkdir -p /etc/nginx/vhosts/
 
 # Process the nginx.conf with raw values of $DOMAIN and $UPSTREAM to ensure backward-compatibility
-  dest="/etc/nginx/nginx.conf"
-  echo "Rendering template of nginx.conf"
-  sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
-      -e "s/\${UPSTREAM}/${UPSTREAM}/" \
-      /templates/nginx.conf > "$dest"
+dest="/etc/nginx/nginx.conf"
+echo "Rendering template of nginx.conf"
+sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
+    -e "s/\${UPSTREAM}/${UPSTREAM}/" \
+    /templates/nginx.conf > "$dest"
 
 
 # Process templates
@@ -117,11 +117,11 @@ if [ $fresh = true ]; then
   echo "The SAN list has changed, removing the old certificate and ask for a new one."
   rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
 
- echo "certbot certonly "${letscmd}" \
-  --standalone --preferred-challenges http --text \
-  "${SERVER}" \
-  --email "${EMAIL}" --agree-tos \
-  --expand " > /etc/nginx/lets
+  echo "certbot certonly "${letscmd}" \
+    --standalone --preferred-challenges http --text \
+    "${SERVER}" \
+    --email "${EMAIL}" --agree-tos \
+    --expand " > /etc/nginx/lets
 
   echo "Running initial certificate request... "
   /bin/bash /etc/nginx/lets

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -143,10 +143,6 @@ EOF
 
 chmod +x ${CRONFILE}
 
-# Kick off cron to reissue certificates as required
-# Background the process and log to stderr
-/usr/sbin/crond -f -d 8 &
-
 echo Ready
 # Launch nginx in the foreground
 /usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
This should fix the issue of cron not kicking off (will confirm asap)

We're set up via Gitlab and I though it might help in general to have public images available automatically, which the added `.gitlab-ci.yml` file gives for free. I have set https://gitlab.com/finestructure/lets-nginx up to mirror https://github.com/smashwilson/lets-nginx .

This will make images available (after `docker login registry.gitlab.com`, accounts are free):

```
docker pull registry.gitlab.com/finestructure/lets-nginx:cbdcfb056b9c950d117eb02a35814d052a6844cd
```

I thought that might be useful to have.

Happy to drop that if you'd rather keep it out of Github and reduce the PR just to the cron fix. Please let me know!