### PR TITLE
Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ MAINTAINER Tarik Benammar <tarik@benammar.com>
 RUN apk add --update bash \
   certbot \
   openssl openssl-dev ca-certificates \
+  fail2ban \
   && rm -rf /var/cache/apk/*
 
-# forward request and error logs to docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx/access.log
-RUN ln -sf /dev/stderr /var/log/nginx/error.log
+# fail2ban setup
+RUN rm /etc/fail2ban/jail.d/*
+COPY fail2ban/jail.local /etc/fail2ban/jail.d/
+COPY fail2ban/filter.d/* /etc/fail2ban/filter.d/
+RUN mkdir -p /var/run/fail2ban
 
 # used for webroot reauth
 RUN mkdir -p /etc/letsencrypt/webrootauth

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:alpine
-MAINTAINER Ash Wilson <smashwilson@gmail.com>
+MAINTAINER Tarik Benammar <tarik@benammar.com>
 
 #We need to install bash to easily handle arrays
 # in the entrypoint.sh script

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN apk add --update bash \
 
 RUN rm -rf /var/cache/apk/*
 
+RUN rm -f /var/log/nginx/* && \
+    touch /var/log/nginx/access.log && \
+    touch /var/log/nginx/error.log
+
 # fail2ban setup
 RUN rm /etc/fail2ban/jail.d/*
 COPY fail2ban/jail.local /etc/fail2ban/jail.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ MAINTAINER Tarik Benammar <tarik@benammar.com>
 RUN apk add --update bash \
   certbot \
   openssl openssl-dev ca-certificates \
-  fail2ban \
-  && rm -rf /var/cache/apk/*
+  fail2ban
+
+RUN rm -rf /var/cache/apk/*
 
 # fail2ban setup
 RUN rm /etc/fail2ban/jail.d/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:mainline-alpine
 MAINTAINER Tarik Benammar <tarik@benammar.com>
 
 #We need to install bash to easily handle arrays
@@ -16,6 +16,7 @@ RUN rm -f /var/log/nginx/* && \
 
 # fail2ban setup
 RUN rm /etc/fail2ban/jail.d/*
+RUN rm -rf /etc/fail2ban/filter.d/*
 COPY fail2ban/jail.local /etc/fail2ban/jail.d/
 COPY fail2ban/filter.d/* /etc/fail2ban/filter.d/
 RUN mkdir -p /var/run/fail2ban

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# Let's Nginx
+# SSL production container
 
-*[dockerhub build](https://hub.docker.com/r/smashwilson/lets-nginx/)*
+Based on docker lets-nginx :  https://github.com/smashwilson/lets-nginx
+
+## fail2ban documentation
+
+You may want to create volume for `/var/log/nginx` in order to keep log files through container life.
+
+Config based on https://www.digitalocean.com/community/tutorials/how-to-protect-an-nginx-server-with-fail2ban-on-ubuntu-14-04
+
+## lets-nginx documentation
 
 Put browser-valid TLS termination in front of any Dockerized HTTP service with one command.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Based on docker lets-nginx :  https://github.com/smashwilson/lets-nginx
 
 You may want to create volume for `/var/log/nginx` in order to keep log files through container life.
 
+Also the container needs to be run with `NET_ADMIN` capability (see: https://github.com/moby/moby/issues/33605#issuecomment-307361421 )
+
 Config based on https://www.digitalocean.com/community/tutorials/how-to-protect-an-nginx-server-with-fail2ban-on-ubuntu-14-04
 
 ## lets-nginx documentation

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -179,6 +179,9 @@ EOF
 
 fi #LE_DOMAIN Section
 
+# Run fail2ban
+fail2ban-client -b -x start
+
 echo Ready
 # Launch nginx in the foreground
 /usr/sbin/nginx -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,12 +107,12 @@ if [ "${LE_DOMAIN}" != "" ]; then
 # Check if the SAN list has changed
  if [ ! -f /etc/letsencrypt/san_list ]; then
   cat <<EOF >/etc/letsencrypt/san_list
-  "${SSL_DOMAIN}"
+  "${LE_DOMAIN}"
 EOF
    fresh=true
  else
    old_san=$(cat /etc/letsencrypt/san_list)
-   if [ "${SSL_DOMAIN}" != "${old_san}" ]; then
+   if [ "${LE_DOMAIN}" != "${old_san}" ]; then
      fresh=true
    else
      fresh=false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,11 +171,11 @@ ${SERVER} \
 /usr/sbin/nginx -s reload
 EOF
 
-# chmod +x /etc/periodic/monthly/reissue
+ chmod +x /etc/periodic/monthly/reissue
 
 # Kick off cron to reissue certificates as required
 # Background the process and log to stderr
-# /usr/sbin/crond -f -d 8 &
+ /usr/sbin/crond -f -d 8 &
 
 fi #LE_DOMAIN Section
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -179,9 +179,10 @@ EOF
 
 fi #LE_DOMAIN Section
 
+echo Ready
+
 # Run fail2ban
 fail2ban-client -b -x start
 
-echo Ready
 # Launch nginx in the foreground
 /usr/sbin/nginx -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,44 +1,30 @@
 #!/bin/bash
 
-set -euo pipefail
-
 # Validate environment variables
 
 MISSING=""
 
-[ -z "${DOMAIN}" ] && MISSING="${MISSING} DOMAIN"
+if [ "${LE_DOMAIN}" == "" ]; then
+  if  [  "${SSL_DOMAIN}" == "" ]; then
+    MISSING="MISSING LE_DOMAIN or SSL_DOMAIN variable"
+  fi 
+fi
+
 [ -z "${UPSTREAM}" ] && MISSING="${MISSING} UPSTREAM"
 
-
-if [ "${MISSING}" != "" ]; then
-  echo "Missing required environment variables:" >&2
-  echo " ${MISSING}" >&2
-  exit 1 
-  fi
-
-#Processing DOMAIN into an array
-DOMAINSARRAY=($(echo "${DOMAIN}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}'))
-echo "Provided domains"
-printf "%s\n" "${DOMAINSARRAY[@]}"
-  
-#Processing UPSTREAM into an array
-UPSTREAMARRAY=($(echo "${UPSTREAM}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}'))
-echo "Services to reverse-proxy"
-printf "%s\n" "${UPSTREAMARRAY[@]}"
-
-#The two arrays should have the same lenght
-if [ "${#DOMAINSARRAY[@]}" != "${#UPSTREAMARRAY[@]}" ]; then
-  echo "The number of domains must match the number of upstream services"
-fi
+set -eo pipefail
 
 # Default other parameters
 SERVER=""
 [ -n "${STAGING:-}" ] && SERVER="--server https://acme-staging.api.letsencrypt.org/directory"
 
-DOMAINALIASARRAY=""
-[ -n "${DOMAINALIAS:-}" ] && DOMAINALIASARRAY=($(echo "${DOMAINALIAS}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}')) && echo "Provided domains alias" && printf "%s\n" "${DOMAINALIASARRAY[@]}"
+[ -n "${LE_DOMAIN:-}" ] && [ -z "${EMAIL}" ] && MISSING="${MISSING} EMAIL"
 
-[ -n "${DOMAINALIAS:-}" ] && [ -z "${EMAIL}" ] && MISSING="${MISSING} EMAIL"
+if [ "${MISSING}" != "" ]; then
+  echo "Missing required environment variables:" >&2
+  echo " ${MISSING}" >&2
+  exit 1
+fi
 
 # Generate strong DH parameters for nginx, if they don't already exist.
 if [ ! -f /etc/ssl/dhparams.pem ]; then
@@ -68,101 +54,94 @@ mkdir -p /etc/nginx/vhosts/
   echo "Rendering template of nginx.conf"
   sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
       -e "s/\${UPSTREAM}/${UPSTREAM}/" \
-      /templates/nginx.conf > "$dest"
+/templates/nginx.conf > "$dest"
 
+if [ "${SSL_DOMAIN}" != "" ]; then
 
-# Process templates
-upstreamId=0
-letscmd=""
-for t in "${DOMAINSARRAY[@]}"
-do
-  dest="/etc/nginx/vhosts/$(basename "${t}").conf"
-  src="/templates/vhost.sample.conf"
+ # Process templates
+ letscmd=""
+ dest="/etc/nginx/vhosts/$(basename "${SSL_DOMAIN}").conf"
+ src="/templates/vhost.sample.conf"
 
-  if [ -r /configs/"${t}".conf ]; then
-    echo "Manual configuration found for $t"
-    src="/configs/${t}.conf"
-  fi
+ if [ -r /configs/"${SSL_DOMAIN}".conf ]; then
+   echo "Manual configuration found for $t"
+   src="/configs/${SSL_DOMAIN}.conf"
+ fi
 
-  echo "Rendering template $src of $t in $dest"
-  sed -e "s/\${DOMAIN}/${t}/g" \
-      -e "s/\${UPSTREAM}/${UPSTREAMARRAY[upstreamId]}/" \
-      -e "s/\${PATH}/${DOMAINSARRAY[0]}/" \
-      "$src" > "$dest"
+ echo "Rendering template $src in $dest"
+ sed -e "s/\${DOMAIN}/${SSL_DOMAIN}/g" \
+  	    -e "s/\${UPSTREAM}/${UPSTREAM}/" \
+ 	    -e "s/\${PATH}/${SSL_DOMAIN}/" \
+	    "$src" > "$dest"
 
-  upstreamId=$((upstreamId+1))
-done
-
-if [ ! -n "${DOMAINALIAS:-}" ]; then
-  echo Ready
-  # Launch nginx in the foreground
-  /usr/sbin/nginx -g "daemon off;"
-  exit 
+ if [ ! -n "${SSL_DOMAIN:-}" ]; then
+   echo Ready
+   # Launch nginx in the foreground
+   /usr/sbin/nginx -g "daemon off;"
+   exit 
+ fi
 fi
+# Process LE SSL template
 
-# Process ALIAS templates
-upstreamId=0
-letscmd=""
-for t in "${DOMAINALIASARRAY[@]}"
-do
-  dest="/etc/nginx/vhosts/$(basename "${t}").conf"
+if [ "${LE_DOMAIN}" != "" ]; then
+
+  letscmd=""
+  dest="/etc/nginx/vhosts/$(basename "${LE_DOMAIN}").conf"
   src="/templates/vhost.le-ssl.sample.conf"
 
-  if [ -r /configs/"${t}".conf ]; then
+  if [ -r /configs/"${LE_DOMAIN}".conf ]; then
     echo "Manual configuration found for $t"
-    src="/configs/${t}.conf"
+    src="/configs/${LE_DOMAIN}.conf"
   fi
 
-  echo "Rendering template $src of $t in $dest"
-  sed -e "s/\${DOMAIN}/${t}/g" \
-      -e "s/\${UPSTREAM}/${UPSTREAMARRAY[upstreamId]}/" \
-      -e "s/\${PATH}/${DOMAINALIASARRAY[0]}/" \
+  echo "Rendering template $src of $LE_DOMAIN in $dest"
+  sed -e "s/\${DOMAIN}/${LE_DOMAIN}/g" \
+      -e "s/\${UPSTREAM}/${UPSTREAM}/" \
+      -e "s/\${PATH}/${LE_DOMAIN}/" \
       "$src" > "$dest"
 
-  upstreamId=$((upstreamId+1))
 
-  #prepare the letsencrypt command arguments
-  letscmd="$letscmd -d $t "
-done
+#prepare the letsencrypt command arguments
+  letscmd="$letscmd -d $LE_DOMAIN "
 
 # Check if the SAN list has changed
-if [ ! -f /etc/letsencrypt/san_list ]; then
- cat <<EOF >/etc/letsencrypt/san_list
- "${DOMAINALIAS}"
+ if [ ! -f /etc/letsencrypt/san_list ]; then
+  cat <<EOF >/etc/letsencrypt/san_list
+  "${SSL_DOMAIN}"
 EOF
-  fresh=true
-else
-  old_san=$(cat /etc/letsencrypt/san_list)
-  if [ "${DOMAINALIAS}" != "${old_san}" ]; then
-    fresh=true
-  else
-    fresh=false
-  fi
-fi
+   fresh=true
+ else
+   old_san=$(cat /etc/letsencrypt/san_list)
+   if [ "${SSL_DOMAIN}" != "${old_san}" ]; then
+     fresh=true
+   else
+     fresh=false
+   fi
+ fi
 
 # Initial certificate request, but skip if cached
-  if [ $fresh = true ]; then
-    echo "The SAN list has changed, removing the old certificate and ask for a new one."
-    rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
+   if [ $fresh = true ]; then
+     echo "The SAN list has changed, removing the old certificate and ask for a new one."
+     rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
 
-   echo "certbot certonly "${letscmd}" \
-    --standalone --text \
-    "${SERVER}" \
-    --email "${EMAIL}" --agree-tos \
-    --expand " > /etc/nginx/lets
+    echo "certbot certonly "${letscmd}" \
+     --standalone --text \
+     "${SERVER}" \
+     --email "${EMAIL}" --agree-tos \
+     --expand " > /etc/nginx/lets
 
-    echo "Running initial certificate request... "
-    /bin/bash /etc/nginx/lets
-  fi
+     echo "Running initial certificate request... "
+     /bin/bash /etc/nginx/lets
+   fi
 
 #update the stored SAN list
-echo "${DOMAINALIAS}" > /etc/letsencrypt/san_list
+ echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
 
 #Create the renewal directory (containing well-known challenges)
-mkdir -p /etc/letsencrypt/webrootauth/
+ mkdir -p /etc/letsencrypt/webrootauth/
 
 # Template a cronjob to reissue the certificate with the webroot authenticator
-echo "Creating a cron job to keep the certificate updated"
+ echo "Creating a cron job to keep the certificate updated"
   cat <<EOF >/etc/periodic/monthly/reissue
 #!/bin/sh
 
@@ -181,11 +160,13 @@ ${SERVER} \
 /usr/sbin/nginx -s reload
 EOF
 
-chmod +x /etc/periodic/monthly/reissue
+ chmod +x /etc/periodic/monthly/reissue
 
 # Kick off cron to reissue certificates as required
 # Background the process and log to stderr
-/usr/sbin/crond -f -d 8 &
+ /usr/sbin/crond -f -d 8 &
+
+fi #LE_DOMAIN Section
 
 echo Ready
 # Launch nginx in the foreground

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,191 +1,101 @@
 #!/bin/bash
+# Prevent script from failing on minor errors during setup
+set -e
 
-# Validate environment variables
-
+# --- 1. Validate environment variables ---
 MISSING=""
-
-if [ "${LE_DOMAIN}" == "" ]; then
-  if  [  "${SSL_DOMAIN}" == "" ]; then
+if [ -z "${LE_DOMAIN}" ] && [ -z "${SSL_DOMAIN}" ]; then
     MISSING="MISSING LE_DOMAIN or SSL_DOMAIN variable"
-  fi 
 fi
 
 [ -z "${UPSTREAM}" ] && MISSING="${MISSING} UPSTREAM"
 
-set -eo pipefail
-
 # Default other parameters
 SERVER=""
 [ -n "${STAGING:-}" ] && SERVER="--server https://acme-staging.api.letsencrypt.org/directory"
-
 [ -n "${LE_DOMAIN:-}" ] && [ -z "${EMAIL}" ] && MISSING="${MISSING} EMAIL"
 
-if [ "${MISSING}" != "" ]; then
-  echo "Missing required environment variables:" >&2
-  echo " ${MISSING}" >&2
-  exit 1
+if [ -n "${MISSING}" ]; then
+    echo "Error: ${MISSING}" >&2
+    exit 1
 fi
 
-#Processing LE_DOMAIN into an array
-DOMAINSARRAY=($(echo "${LE_DOMAIN}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}'))
-echo "Provided domains"
-printf "%s\n" "${DOMAINSARRAY[@]}"
+# --- 2. Prepare Filesystem & Logs ---
+# Fail2Ban will CRASH if these files don't exist on start
+mkdir -p /var/log/nginx /var/run/fail2ban /etc/nginx/vhosts /etc/letsencrypt/webrootauth
+touch /var/log/nginx/access.log /var/log/nginx/error.log
+rm -f /var/run/fail2ban/fail2ban.sock # Clean up stale sockets from previous crashes
 
-# Generate strong DH parameters for nginx, if they don't already exist.
+# Process domains into array
+IFS=';' read -r -a DOMAINSARRAY <<< "${LE_DOMAIN}"
+echo "Configuring for domains: ${DOMAINSARRAY[*]}"
+
+# --- 3. Diffie-Hellman Parameters ---
 if [ ! -f /etc/ssl/dhparams.pem ]; then
-  if [ -f /cache/dhparams.pem ]; then
-    cp /cache/dhparams.pem /etc/ssl/dhparams.pem
-  else
-    openssl dhparam -out /etc/ssl/dhparams.pem 2048
-   # Cache to a volume for next time?
-    if [ -d /cache ]; then
-     cp /etc/ssl/dhparams.pem /cache/dhparams.pem
+    if [ -f /cache/dhparams.pem ]; then
+        cp /cache/dhparams.pem /etc/ssl/dhparams.pem
+    else
+        echo "Generating DH parameters (2048 bit)... this may take a moment."
+        openssl dhparam -out /etc/ssl/dhparams.pem 2048
+        [ -d /cache ] && cp /etc/ssl/dhparams.pem /cache/dhparams.pem
     fi
-  fi
 fi
 
-#create temp file storage
-mkdir -p /var/cache/nginx
-chown nginx:nginx /var/cache/nginx
+# --- 4. Template Rendering ---
+echo "Rendering nginx.conf"
+sed -e "s/\${DOMAIN}/${DOMAIN}/g" -e "s/\${UPSTREAM}/${UPSTREAM}/" /templates/nginx.conf > /etc/nginx/nginx.conf
 
-mkdir -p /var/tmp/nginx
-chown nginx:nginx /var/tmp/nginx
-
-#create vhost directory
-mkdir -p /etc/nginx/vhosts/
-
-# Process the nginx.conf with raw values of $DOMAIN and $UPSTREAM to ensure backward-compatibility
-  dest="/etc/nginx/nginx.conf"
-  echo "Rendering template of nginx.conf"
-  sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
-      -e "s/\${UPSTREAM}/${UPSTREAM}/" \
-/templates/nginx.conf > "$dest"
-
-if [ "${SSL_DOMAIN}" != "" ]; then
-
- # Process templates
- letscmd=""
- dest="/etc/nginx/vhosts/$(basename "${SSL_DOMAIN}").conf"
- src="/templates/vhost.sample.conf"
-
- if [ -r /configs/"${SSL_DOMAIN}".conf ]; then
-   echo "Manual configuration found for $t"
-   src="/configs/${SSL_DOMAIN}.conf"
- fi
-
- echo "Rendering template $src in $dest"
- sed -e "s/\${DOMAIN}/${SSL_DOMAIN}/g" \
-  	    -e "s/\${UPSTREAM}/${UPSTREAM}/" \
- 	    -e "s/\${PATH}/${SSL_DOMAIN}/" \
-	    "$src" > "$dest"
-
- if [ ! -n "${SSL_DOMAIN:-}" ]; then
-   echo Ready
-   # Launch nginx in the foreground
-   /usr/sbin/nginx -g "daemon off;"
-   exit 
- fi
+# Render SSL vhosts
+if [ -n "${SSL_DOMAIN}" ]; then
+    dest="/etc/nginx/vhosts/$(basename "${SSL_DOMAIN}").conf"
+    src="/templates/vhost.sample.conf"
+    [ -r "/configs/${SSL_DOMAIN}.conf" ] && src="/configs/${SSL_DOMAIN}.conf"
+    
+    sed -e "s/\${DOMAIN}/${SSL_DOMAIN}/g" -e "s/\${UPSTREAM}/${UPSTREAM}/" -e "s/\${PATH}/${SSL_DOMAIN}/" "$src" > "$dest"
 fi
 
-# Process LE SSL template
+# --- 5. Let's Encrypt Logic ---
+if [ -n "${LE_DOMAIN}" ]; then
+    letscmd=""
+    for t in "${DOMAINSARRAY[@]}"; do
+        dest="/etc/nginx/vhosts/$(basename "${t}").conf"
+        src="/templates/vhost.le-ssl.sample.conf"
+        [ -r "/configs/${t}.conf" ] && src="/configs/${t}.conf"
+        
+        sed -e "s/\${DOMAIN}/${t}/g" -e "s/\${UPSTREAM}/${UPSTREAM}/" -e "s/\${PATH}/${DOMAINSARRAY[0]}/" "$src" > "$dest"
+        letscmd="$letscmd -d $t"
+    done
 
-if [ "${LE_DOMAIN}" != "" ]; then
-
-  letscmd=""
-  for t in "${DOMAINSARRAY[@]}"
-  do
-    dest="/etc/nginx/vhosts/$(basename "${t}").conf"
-    src="/templates/vhost.le-ssl.sample.conf"
-
-    if [ -r /configs/"${t}".conf ]; then
-      echo "Manual configuration found for $t"
-      src="/configs/${t}.conf"
+    # Check for SAN changes
+    fresh=false
+    if [ ! -f /etc/letsencrypt/san_list ] || [ "$(cat /etc/letsencrypt/san_list)" != "${LE_DOMAIN}" ]; then
+        echo "SAN list changed or new install. Resetting certs."
+        rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
+        fresh=true
     fi
 
-    echo "Rendering template $src of $t in $dest"
-    sed -e "s/\${DOMAIN}/${t}/g" \
-        -e "s/\${UPSTREAM}/${UPSTREAM}/" \
-        -e "s/\${PATH}/${DOMAINSARRAY[0]}/" \
-        "$src" > "$dest"
+    if [ "$fresh" = true ]; then
+        echo "Requesting initial certificates..."
+        certbot certonly $letscmd --standalone --non-interactive --agree-tos --email "${EMAIL}" ${SERVER} --expand
+        echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
+    fi
 
+    # Update cli.ini (Removed the expired DST Root CA X3 reference)
+    echo "preferred-chain = ISRG Root X1" > /etc/letsencrypt/cli.ini
 
-    #prepare the letsencrypt command arguments
-    letscmd="$letscmd -d $t "
-  done
-
-echo $letscmd
-
-# Check if the SAN list has changed
- if [ ! -f /etc/letsencrypt/san_list ]; then
-  cat <<EOF >/etc/letsencrypt/san_list
-  "${LE_DOMAIN}"
+    # Setup Renewal Cron
+    cat <<EOF > /etc/periodic/monthly/reissue
+#!/bin/bash
+certbot renew --webroot -w /etc/letsencrypt/webrootauth/ --post-hook "nginx -s reload"
 EOF
-   fresh=true
- else
-   old_san=$(cat /etc/letsencrypt/san_list)
-   if [ "${LE_DOMAIN}" != "${old_san}" ]; then
-     fresh=true
-   else
-     fresh=false
-   fi
- fi
+    chmod +x /etc/periodic/monthly/reissue
+    /usr/sbin/crond -b # Start cron in background
+fi
 
-# Initial certificate request, but skip if cached
-   if [ $fresh = true ]; then
-     echo "The SAN list has changed, removing the old certificate and ask for a new one."
-     rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
+# --- 6. Launch Services ---
+echo "Starting Fail2Ban..."
+# -b starts in background, -x ensures it cleans up previous server remains
+fail2ban-server -b -x
 
-    echo "certbot certonly "${letscmd}" \
-     --standalone --text \
-     "${SERVER}" \
-     --email "${EMAIL}" --agree-tos \
-     --expand " > /etc/nginx/lets
-
-     echo "Running initial certificate request... "
-     /bin/bash /etc/nginx/lets
-   fi
-
-#update the stored SAN list
- echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
-
-#Create the renewal directory (containing well-known challenges)
- mkdir -p /etc/letsencrypt/webrootauth/
-
- #Preparing for the ISRG Root transition (January 11 2021)
- echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
-
-# Template a cronjob to reissue the certificate with the webroot authenticator
- echo "Creating a cron job to keep the certificate updated"
-  cat <<EOF >/etc/periodic/monthly/reissue
-#!/bin/sh
-
-set -euo pipefail
-
-# Certificate reissue
-certbot certonly --force-renewal \
---webroot --text \
--w /etc/letsencrypt/webrootauth/ \
-${letscmd} \
-${SERVER} \
---email "${EMAIL}" --agree-tos \
---expand
-
-# Reload nginx configuration to pick up the reissued certificates
-/usr/sbin/nginx -s reload
-EOF
-
- chmod +x /etc/periodic/monthly/reissue
-
-# Kick off cron to reissue certificates as required
-# Background the process and log to stderr
- /usr/sbin/crond -f -d 8 &
-
-fi #LE_DOMAIN Section
-
-echo Ready
-
-# Run fail2ban
-fail2ban-client -b -x start
-
-# Launch nginx in the foreground
-/usr/sbin/nginx -g "daemon off;"
+echo "Starting Nginx..."
+exec nginx -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,6 +145,9 @@ EOF
      /bin/bash /etc/nginx/lets
    fi
 
+#Preparing for the ISRG Root transition (January 11 2021)
+ echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
+
 #update the stored SAN list
  echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,15 +145,15 @@ EOF
      /bin/bash /etc/nginx/lets
    fi
 
-#Preparing for the ISRG Root transition (January 11 2021)
- echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
-
 #update the stored SAN list
  echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
 
 #Create the renewal directory (containing well-known challenges)
  mkdir -p /etc/letsencrypt/webrootauth/
-:
+
+ #Preparing for the ISRG Root transition (January 11 2021)
+ echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
+
 # Template a cronjob to reissue the certificate with the webroot authenticator
  echo "Creating a cron job to keep the certificate updated"
   cat <<EOF >/etc/periodic/monthly/reissue

--- a/fail2ban/filter.d/nginx-badbots.conf
+++ b/fail2ban/filter.d/nginx-badbots.conf
@@ -1,0 +1,21 @@
+# Fail2Ban configuration file
+#
+# Regexp to catch known spambots and software alike. Please verify
+# that it is your intent to block IPs which were driven by
+# above mentioned bots.
+
+
+[Definition]
+
+badbotscustom = EmailCollector|WebEMailExtrac|TrackBack/1\.02|sogou music spider
+badbots = Atomic_Email_Hunter/4\.0|atSpider/1\.0|autoemailspider|bwh3_user_agent|China Local Browse 2\.6|ContactBot/0\.2|ContentSmartz|DataCha0s/2\.0|DBrowse 1\.4b|DBrowse 1\.4d|Demo Bot DOT 16b|Demo Bot Z 16b|DSurf15a 01|DSurf15a 71|DSurf15a 81|DSurf15a VA|EBrowse 1\.4b|Educate Search VxB|EmailSiphon|EmailSpider|EmailWolf 1\.00|ESurf15a 15|ExtractorPro|Franklin Locator 1\.8|FSurf15a 01|Full Web Bot 0416B|Full Web Bot 0516B|Full Web Bot 2816B|Guestbook Auto Submitter|Industry Program 1\.0\.x|ISC Systems iRc Search 2\.1|IUPUI Research Bot v 1\.9a|LARBIN-EXPERIMENTAL \(efp@gmx\.net\)|LetsCrawl\.com/1\.0 +http\://letscrawl\.com/|Lincoln State Web Browser|LMQueueBot/0\.2|LWP\:\:Simple/5\.803|Mac Finder 1\.0\.xx|MFC Foundation Class Library 4\.0|Microsoft URL Control - 6\.00\.8xxx|Missauga Locate 1\.0\.0|Missigua Locator 1\.9|Missouri College Browse|Mizzu Labs 2\.2|Mo College 1\.9|MVAClient|Mozilla/2\.0 \(compatible; NEWT ActiveX; Win32\)|Mozilla/3\.0 \(compatible; Indy Library\)|Mozilla/3\.0 \(compatible; scan4mail \(advanced version\) http\://www\.peterspages\.net/?scan4mail\)|Mozilla/4\.0 \(compatible; Advanced Email Extractor v2\.xx\)|Mozilla/4\.0 \(compatible; Iplexx Spider/1\.0 http\://www\.iplexx\.at\)|Mozilla/4\.0 \(compatible; MSIE 5\.0; Windows NT; DigExt; DTS Agent|Mozilla/4\.0 efp@gmx\.net|Mozilla/5\.0 \(Version\: xxxx Type\:xx\)|NameOfAgent \(CMS Spider\)|NASA Search 1\.0|Nsauditor/1\.x|PBrowse 1\.4b|PEval 1\.4b|Poirot|Port Huron Labs|Production Bot 0116B|Production Bot 2016B|Production Bot DOT 3016B|Program Shareware 1\.0\.2|PSurf15a 11|PSurf15a 51|PSurf15a VA|psycheclone|RSurf15a 41|RSurf15a 51|RSurf15a 81|searchbot admin@google\.com|ShablastBot 1\.0|snap\.com beta crawler v0|Snapbot/1\.0|Snapbot/1\.0 \(Snap Shots&#44; +http\://www\.snap\.com\)|sogou develop spider|Sogou Orion spider/3\.0\(+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sogou spider|Sogou web spider/3\.0\(+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sohu agent|SSurf15a 11 |TSurf15a 11|Under the Rainbow 2\.2|User-Agent\: Mozilla/4\.0 \(compatible; MSIE 6\.0; Windows NT 5\.1\)|VadixBot|WebVulnCrawl\.unknown/1\.0 libwww-perl/5\.803|Wells Search II|WEP Search 00
+
+failregex = ^<HOST> -.*"(GET|POST).*HTTP.*"(?:%(badbots)s|%(badbotscustom)s)"$
+
+ignoreregex =
+
+# DEV Notes:
+# List of bad bots fetched from http://www.user-agents.org
+# Generated on Thu Nov  7 14:23:35 PST 2013 by files/gen_badbots.
+#
+# Author: Yaroslav Halchenko

--- a/fail2ban/filter.d/nginx-badbots.conf
+++ b/fail2ban/filter.d/nginx-badbots.conf
@@ -7,10 +7,10 @@
 
 [Definition]
 
-badbotscustom = EmailCollector|WebEMailExtrac|TrackBack/1\.02|sogou music spider
+badbotscustom = EmailCollector|WebEMailExtrac|TrackBack/1\.02|sogou music spider|SEMrushBot
 badbots = Atomic_Email_Hunter/4\.0|atSpider/1\.0|autoemailspider|bwh3_user_agent|China Local Browse 2\.6|ContactBot/0\.2|ContentSmartz|DataCha0s/2\.0|DBrowse 1\.4b|DBrowse 1\.4d|Demo Bot DOT 16b|Demo Bot Z 16b|DSurf15a 01|DSurf15a 71|DSurf15a 81|DSurf15a VA|EBrowse 1\.4b|Educate Search VxB|EmailSiphon|EmailSpider|EmailWolf 1\.00|ESurf15a 15|ExtractorPro|Franklin Locator 1\.8|FSurf15a 01|Full Web Bot 0416B|Full Web Bot 0516B|Full Web Bot 2816B|Guestbook Auto Submitter|Industry Program 1\.0\.x|ISC Systems iRc Search 2\.1|IUPUI Research Bot v 1\.9a|LARBIN-EXPERIMENTAL \(efp@gmx\.net\)|LetsCrawl\.com/1\.0 +http\://letscrawl\.com/|Lincoln State Web Browser|LMQueueBot/0\.2|LWP\:\:Simple/5\.803|Mac Finder 1\.0\.xx|MFC Foundation Class Library 4\.0|Microsoft URL Control - 6\.00\.8xxx|Missauga Locate 1\.0\.0|Missigua Locator 1\.9|Missouri College Browse|Mizzu Labs 2\.2|Mo College 1\.9|MVAClient|Mozilla/2\.0 \(compatible; NEWT ActiveX; Win32\)|Mozilla/3\.0 \(compatible; Indy Library\)|Mozilla/3\.0 \(compatible; scan4mail \(advanced version\) http\://www\.peterspages\.net/?scan4mail\)|Mozilla/4\.0 \(compatible; Advanced Email Extractor v2\.xx\)|Mozilla/4\.0 \(compatible; Iplexx Spider/1\.0 http\://www\.iplexx\.at\)|Mozilla/4\.0 \(compatible; MSIE 5\.0; Windows NT; DigExt; DTS Agent|Mozilla/4\.0 efp@gmx\.net|Mozilla/5\.0 \(Version\: xxxx Type\:xx\)|NameOfAgent \(CMS Spider\)|NASA Search 1\.0|Nsauditor/1\.x|PBrowse 1\.4b|PEval 1\.4b|Poirot|Port Huron Labs|Production Bot 0116B|Production Bot 2016B|Production Bot DOT 3016B|Program Shareware 1\.0\.2|PSurf15a 11|PSurf15a 51|PSurf15a VA|psycheclone|RSurf15a 41|RSurf15a 51|RSurf15a 81|searchbot admin@google\.com|ShablastBot 1\.0|snap\.com beta crawler v0|Snapbot/1\.0|Snapbot/1\.0 \(Snap Shots&#44; +http\://www\.snap\.com\)|sogou develop spider|Sogou Orion spider/3\.0\(+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sogou spider|Sogou web spider/3\.0\(+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sohu agent|SSurf15a 11 |TSurf15a 11|Under the Rainbow 2\.2|User-Agent\: Mozilla/4\.0 \(compatible; MSIE 6\.0; Windows NT 5\.1\)|VadixBot|WebVulnCrawl\.unknown/1\.0 libwww-perl/5\.803|Wells Search II|WEP Search 00
 
-failregex = ^<HOST> -.*"(GET|POST).*HTTP.*"(?:%(badbots)s|%(badbotscustom)s)"$
+failregex = ^<HOST> -.*"(GET|POST|HEAD).*HTTP.*"(?:%(badbots)s|%(badbotscustom)s)"$
 
 ignoreregex =
 

--- a/fail2ban/filter.d/nginx-http-auth.conf
+++ b/fail2ban/filter.d/nginx-http-auth.conf
@@ -1,0 +1,16 @@
+# fail2ban filter configuration for nginx
+
+
+[Definition]
+
+
+failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S+, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"\s*$
+            ^ \[error\] \d+#\d+: \*\d+ no user/password was provided for basic authentication, client: <HOST>, server: \S+, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"\s*$
+
+ignoreregex = 
+
+# DEV NOTES:
+# Based on samples in https://github.com/fail2ban/fail2ban/pull/43/files
+# Extensive search of all nginx auth failures not done yet.
+# 
+# Author: Daniel Black

--- a/fail2ban/filter.d/nginx-nohome.conf
+++ b/fail2ban/filter.d/nginx-nohome.conf
@@ -1,0 +1,5 @@
+[Definition]
+
+failregex = ^<HOST> -.*GET .*/~.*
+
+ignoreregex =

--- a/fail2ban/filter.d/nginx-noproxy.conf
+++ b/fail2ban/filter.d/nginx-noproxy.conf
@@ -1,0 +1,5 @@
+[Definition]
+
+failregex = ^<HOST> -.*GET http.*
+
+ignoreregex =

--- a/fail2ban/filter.d/nginx-noscript.conf
+++ b/fail2ban/filter.d/nginx-noscript.conf
@@ -1,0 +1,5 @@
+[Definition]
+
+failregex = ^<HOST> -.*GET.*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi)
+
+ignoreregex =

--- a/fail2ban/filter.d/nginx-noscript.conf
+++ b/fail2ban/filter.d/nginx-noscript.conf
@@ -1,5 +1,5 @@
 [Definition]
 
-failregex = ^<HOST> -.*GET.*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi)
+failregex = ^<HOST> -.*GET.*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi).*HTTP
 
 ignoreregex =

--- a/fail2ban/jail.local
+++ b/fail2ban/jail.local
@@ -1,0 +1,59 @@
+[DEFAULT]
+
+ignoreip = 127.0.0.1/8
+
+# "bantime" is the number of seconds that a host is banned.
+bantime  = 86400
+# A host is banned if it has generated "maxretry" during the last "findtime"
+findtime = 600
+maxretry = 5
+
+## Send email alert (TODO?)
+destemail = root@localhost
+sendername = Fail2Ban
+sender = fail2ban@localhost
+
+[ssh]
+
+enabled  = false
+
+[nginx-http-auth]
+
+enabled = true
+filter  = nginx-http-auth
+port    = http,https
+logpath = /var/log/nginx/error.log
+maxretry = 10
+
+[nginx-badbots]
+
+enabled  = true
+port     = http,https
+filter   = nginx-badbots
+logpath  = /var/log/nginx/access.log
+maxretry = 3
+
+[nginx-noscript]
+
+enabled  = true
+port     = http,https
+filter   = nginx-noscript
+logpath  = /var/log/nginx/access.log
+maxretry = 6
+
+[nginx-nohome]
+
+enabled  = true
+filter   = nginx-nohome
+port     = http,https
+logpath  = /var/log/nginx/access.log
+maxretry = 3
+
+[nginx-noproxy]
+
+enabled  = true
+port     = http,https
+filter   = nginx-noproxy
+logpath  = /var/log/nginx/access.log
+maxretry = 3
+

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -20,6 +20,9 @@ http {
   access_log /var/log/nginx/access.log;
   error_log /var/log/nginx/error.log;
 
+  access_log /dev/stdout;
+  error_log /dev/stdout;
+
   map $http_upgrade $connection_upgrade {
       default upgrade;
       ''      close;

--- a/templates/vhost.le-ssl.sample.conf
+++ b/templates/vhost.le-ssl.sample.conf
@@ -2,6 +2,10 @@ server {
     listen 443 ssl http2;
     server_name ${DOMAIN};
 
+    if ($http_user_agent ~ ".*SEMrushBot.*") {
+      return 301 "http://semrush.com/";
+    }
+
     ssl_certificate /etc/letsencrypt/live/${PATH}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${PATH}/privkey.pem;
     ssl_dhparam /etc/ssl/dhparams.pem;
@@ -34,6 +38,11 @@ server {
   server {
     listen 80;
     server_name ${DOMAIN};
+
+    if ($http_user_agent ~ ".*SEMrushBot.*") {
+      return 301 "http://semrush.com/";
+    }
+
     location / {
       proxy_pass http://${UPSTREAM};
       proxy_set_header Host $host;

--- a/templates/vhost.le-ssl.sample.conf
+++ b/templates/vhost.le-ssl.sample.conf
@@ -1,9 +1,9 @@
 server {
     listen 443 ssl http2;
-    server_name ${DOMAIN} www.${DOMAIN};
+    server_name ${DOMAIN};
 
-    ssl_certificate /etc/ssl/certs/${PATH}/fullchain.crt;
-    ssl_certificate_key /etc/ssl/certs/${PATH}/privkey.key;
+    ssl_certificate /etc/letsencrypt/live/${PATH}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${PATH}/privkey.pem;
     ssl_dhparam /etc/ssl/dhparams.pem;
 
     ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
@@ -17,6 +17,8 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
 
+    root /etc/letsencrypt/webrootauth;
+
     location / {
       proxy_pass http://${UPSTREAM};
       proxy_set_header Host $host;
@@ -29,11 +31,17 @@ server {
       proxy_set_header Connection $http_connection;      
     }
 
- }
+    location /.well-known/acme-challenge {
+      alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
+      location ~ /.well-known/acme-challenge/(.*) {
+        add_header Content-Type application/jose+json;
+      }
+    }
+  }
 
   server {
     listen 80;
-    server_name ${DOMAIN} www.${DOMAIN};
+    server_name ${DOMAIN};
     location / {
       proxy_pass http://${UPSTREAM};
       proxy_set_header Host $host;

--- a/templates/vhost.le-ssl.sample.conf
+++ b/templates/vhost.le-ssl.sample.conf
@@ -31,6 +31,7 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $http_connection;      
+      proxy_set_header X-Request-Start "t=${msec}";
     }
 
   }

--- a/templates/vhost.le-ssl.sample.conf
+++ b/templates/vhost.le-ssl.sample.conf
@@ -17,8 +17,6 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
 
-    root /etc/letsencrypt/webrootauth;
-
     location / {
       proxy_pass http://${UPSTREAM};
       proxy_set_header Host $host;
@@ -31,12 +29,6 @@ server {
       proxy_set_header Connection $http_connection;      
     }
 
-    location /.well-known/acme-challenge {
-      alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
-      location ~ /.well-known/acme-challenge/(.*) {
-        add_header Content-Type application/jose+json;
-      }
-    }
   }
 
   server {
@@ -52,4 +44,14 @@ server {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $http_connection;
     }
+    
+    root /etc/letsencrypt/webrootauth;
+
+     location /.well-known/acme-challenge {
+      alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
+      location ~ /.well-known/acme-challenge/(.*) {
+        add_header Content-Type application/jose+json;
+      }
+    }
+
   } 

--- a/templates/vhost.le-ssl.sample.conf
+++ b/templates/vhost.le-ssl.sample.conf
@@ -43,6 +43,7 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $http_connection;
+      proxy_set_header X-Request-Start "t=${msec}";
     }
     
     root /etc/letsencrypt/webrootauth;

--- a/templates/vhost.le-ssl.sample.conf
+++ b/templates/vhost.le-ssl.sample.conf
@@ -2,9 +2,10 @@ server {
     listen 443 ssl http2;
     server_name ${DOMAIN};
 
-    if ($http_user_agent ~ ".*SEMrushBot.*") {
-      return 301 "http://semrush.com/";
+    if ($http_user_agent ~* (thesis-research-bot|Bytespider|AmazonBot|AhrefsBot|BaiduSpider|Jooblebot|NetSpider) ) {
+    return 410;
     }
+
 
     ssl_certificate /etc/letsencrypt/live/${PATH}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${PATH}/privkey.pem;
@@ -40,8 +41,8 @@ server {
     listen 80;
     server_name ${DOMAIN};
 
-    if ($http_user_agent ~ ".*SEMrushBot.*") {
-      return 301 "http://semrush.com/";
+    if ($http_user_agent ~* (thesis-research-bot|Bytespider|AmazonBot|AhrefsBot|BaiduSpider|Jooblebot|NetSpider) ) {
+    return 410;
     }
 
     location / {

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -53,5 +53,6 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $http_connection;
+      proxy_set_header X-Request-Start "t=${msec}";
     }
   } 

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -27,6 +27,7 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $http_connection;      
+      proxy_set_header X-Request-Start "t=${msec}";
     }
 
  }

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -39,9 +39,17 @@ server {
     }
   }
 
-  # Redirect from port 80 to port 443
   server {
     listen 80;
     server_name ${DOMAIN};
-    return 301 https://$server_name$request_uri;
-  }
+    location / {
+      proxy_pass http://${UPSTREAM};
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_cache   anonymous;
+      proxy_buffering off;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $http_connection;
+    }
+  } 

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -2,6 +2,10 @@ server {
     listen 443 ssl http2;
     server_name ${DOMAIN} www.${DOMAIN};
 
+    if ($http_user_agent ~ ".*SEMrushBot.*") {
+      return 301 "http://semrush.com/";
+    }
+
     ssl_certificate /etc/ssl/certs/${PATH}/fullchain.crt;
     ssl_certificate_key /etc/ssl/certs/${PATH}/privkey.key;
     ssl_dhparam /etc/ssl/dhparams.pem;
@@ -35,6 +39,11 @@ server {
   server {
     listen 80;
     server_name ${DOMAIN} www.${DOMAIN};
+
+    if ($http_user_agent ~ ".*SEMrushBot.*") {
+      return 301 "http://semrush.com/";
+    }
+
     location / {
       proxy_pass http://${UPSTREAM};
       proxy_set_header Host $host;

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -2,9 +2,9 @@ server {
     listen 443 ssl http2;
     server_name ${DOMAIN} www.${DOMAIN};
 
-    if ($http_user_agent ~ ".*SEMrushBot.*") {
-      return 301 "http://semrush.com/";
-    }
+    if ($http_user_agent ~* (Bytespider|AmazonBot|AhrefsBot|BaiduSpider|Jooblebot|NetSpider) ) {
+    return 410;
+    }    
 
     ssl_certificate /etc/ssl/certs/${PATH}/fullchain.crt;
     ssl_certificate_key /etc/ssl/certs/${PATH}/privkey.key;


### PR DESCRIPTION
 Refactor: harden entrypoint and update SSL root chain
    
    - Commited local changes by Louis I guess retaled to failt2ban
    - Added cleanup for /var/run/fail2ban/fail2ban.sock to prevent restart failures.
    - Ensured Nginx logs exist before Fail2Ban starts to prevent service crashes.
    - Updated Let's Encrypt preferred-chain to ISRG Root X1 (replacing expired DST Root).
    - Optimized domain array processing using IFS.
    - Replaced manual backgrounding with `exec` for better Docker signal handling.